### PR TITLE
don't give static value for date field default

### DIFF
--- a/notes/models.py
+++ b/notes/models.py
@@ -32,7 +32,7 @@ class Note(TimeStampedModel):
     A simple model to handle adding arbitrary numbers of notes to an animal profile.
     """
     topic=models.ForeignKey(Topic)
-    date=models.DateField(_('Date'), default=datetime.now())
+    date=models.DateField(_('Date'), default=date.today)
     content=models.TextField(_('Content'))
     public=models.BooleanField(_('Public'), default=True)
     author=models.ForeignKey(User, blank=True, null=True)


### PR DESCRIPTION
Fix for:
> System check identified some issues:
> 
> WARNINGS:
> notes.Note.date: (fields.W161) Fixed default value provided.
> 	HINT: It seems you set a fixed date / time / datetime value as default for this field. This may not be what you want. If you want to have the current date as default, use `django.utils.timezone.now`